### PR TITLE
doc: fix Incorrect order in util.parseArgs history

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1380,15 +1380,15 @@ added:
   - v18.3.0
   - v16.17.0
 changes:
-  - version: v18.11.0
-    pr-url: https://github.com/nodejs/node/pull/44631
-    description: Add support for default values in input `config`.
-  - version:
+- version:
     - v18.7.0
     - v16.17.0
     pr-url: https://github.com/nodejs/node/pull/43459
     description: add support for returning detailed parse information
                  using `tokens` in input `config` and returned properties.
+  - version: v18.11.0
+    pr-url: https://github.com/nodejs/node/pull/44631
+    description: Add support for default values in input `config`.
 -->
 
 > Stability: 1 - Experimental


### PR DESCRIPTION
fix incorrect order in util.parseArgs history in the util.md

Fixed ordering in the versioning history for the util.parseArgs function in the util.md.

Fixes: -https://github.com/nodejs/node/issues/45670

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
